### PR TITLE
fizzbuzz_printer typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ reverse_string("hello")
 # => "olleh"
 ```
 
-Write a method `#fizzbuzz` that prints the numbers from 1 to 100. For
+Write a method `#fizzbuzz_printer` that prints the numbers from 1 to 100. For
 multiples of three, print "Fizz" instead of the number and for the multiples
 of five print "Buzz". For numbers which are multiples of both three and five,
 print "FizzBuzz".


### PR DESCRIPTION
Change the method to `fizzbuzz_printer` in the README.md in order to satisfy test conditions in `looping_spec`